### PR TITLE
useResizeObserver: Add ref parameter to the hook itself.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ import React, { useRef } from 'react'
 import useResizeObserver from 'resize-observer-hook'
 
 const App = () => {
-  const ref = useRef()
-  const [width, height] = useResizeObserver(ref)
+  const [ref, width, height] = useResizeObserver(ref)
 
   return (
     <div ref={ref}>

--- a/src/useResizeObserver.js
+++ b/src/useResizeObserver.js
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 
-const useResizeObserver = (ref) => {
+const useResizeObserver = () => {
+  const ref = useRef(null)
   const [height, setHeight] = useState()
   const [width, setWidth] = useState()
 
@@ -25,7 +26,7 @@ const useResizeObserver = (ref) => {
     }
   }
 
-  return [width, height]
+  return [ref, width, height]
 }
 
 export default useResizeObserver


### PR DESCRIPTION
The following code solves #1 by adding the ref parameter in the hook itself. Also, changed the README.md file accordingly.


Fixes: #1 
Signed-off-by: Gautam Arora <gautamarora6248@gmail.com>