### PR TITLE
Correct "Usage section" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ npm install --save resize-observer-hook
 ## Usage
 
 ```jsx
-import React, { useRef } from 'react'
+import React from 'react'
 
 import useResizeObserver from 'resize-observer-hook'
 
 const App = () => {
-  const [ref, width, height] = useResizeObserver(ref)
+  const [ref, width, height] = useResizeObserver()
 
   return (
     <div ref={ref}>


### PR DESCRIPTION
Remove the `useRef` import from the Usage section in the README.md file.
Also, removed the ref parameter from the hook.



Fixes: #8 
Signed-off-by: Gautam Arora <gautamarora6248@gmail.com>