### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Install
 
 ```bash
-npm install --save resize-observer-hook
+npm install resize-observer-hook
 ```
 
 ## Usage


### PR DESCRIPTION
Changed this command : 
npm install --save resize-observer-hook

To this:
npm install resize-observer-hook

As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. We can safely remove the --save configuration from the command written in the README.md file.