### PR TITLE
fix: pass ”dependencies array“ to useEffect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,13 @@ const useResizeObserver = (option = 'contentRect') => {
   const ref = useRef(null);
   const [height, setHeight] = useState();
   const [width, setWidth] = useState();
-
+  const element = ref.current
   useEffect(() => {
-    if (ref.current) {
+    if (element) {
       const observer = new ResizeObserver((entries) => {
         handleResize(entries);
       });
-      observer.observe(ref.current);
+      observer.observe(element);
 
       // Callback fired when component is unmounted
       return () => {
@@ -19,7 +19,7 @@ const useResizeObserver = (option = 'contentRect') => {
     }
     // Added this return for eslint rule -> no-consisten-return
     return undefined;
-  });
+  },[element]);
 
   function handleResize(entries) {
     for (const entry of entries) {


### PR DESCRIPTION
As far as I know, If dependencies array is undefined, useEffect will run after every render.

A new ResizeObserver will be created everytime after ”setWidth/setHeight“ is called.

It may shouldn't happen when ref.current doesn’t change?